### PR TITLE
deps: bump `time`, fix build for rust 1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1125,9 +1125,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
The build fails with rust 1.80 due to an outdated `time` crate. This can be simply fixed by `cargo update time`. A bugfix release would be even better. 

See:
- https://github.com/time-rs/time/issues/693
- https://github.com/NixOS/nixpkgs/issues/332957
- log: https://hydra.nixos.org/build/269127050/nixlog/1